### PR TITLE
Casminst 3857

### DIFF
--- a/kubernetes/cray-ceph-csi-rbd/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-rbd
-version: 3.4.0
+version: 3.5.1
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter, and attacher for Ceph RBD
 keywords:
   - ceph
@@ -11,9 +11,9 @@ sources:
   - https://github.com/ceph/ceph-csi/tree/v3.4.0/charts/ceph-csi-rbd
 dependencies:
   - name: ceph-csi-rbd
-    version: 3.4.0
+    version: 3.5.1
     repository: https://ceph.github.io/csi-charts
 maintainers:
   - name: bklei
 icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.4.0/assets/ceph-logo.png
-appVersion: 3.4.0
+appVersion: 3.5.1

--- a/kubernetes/cray-ceph-csi-rbd/templates/ceph-csi-job-perms.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/templates/ceph-csi-job-perms.yaml
@@ -42,14 +42,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: ceph-csi-sa
-  namespace: default
+  namespace: ceph-rbd
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ceph-csi-sa
-  namespace: default
+  namespace: ceph-rbd
   labels:
     app: ceph-csi
 

--- a/kubernetes/cray-ceph-csi-rbd/values.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/values.yaml
@@ -98,7 +98,7 @@ ceph-csi-rbd:
     registrar:
       image:
         repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-        tag: v2.2.0
+        tag: v2.4.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -107,7 +107,7 @@ ceph-csi-rbd:
         # XXX quay.io/cephcsi/cephcsi:v3.4.0 has 4 critical (of 8)
         # XXX vulnerabilities, so we're rebuilding it to resolve them.
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
-        tag: v3.4.0
+        tag: v3.5.1
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -188,7 +188,7 @@ ceph-csi-rbd:
     provisioner:
       image:
         repository: k8s.gcr.io/sig-storage/csi-provisioner
-        tag: v2.2.2
+        tag: v3.1.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -197,7 +197,7 @@ ceph-csi-rbd:
       enabled: true
       image:
         repository: k8s.gcr.io/sig-storage/csi-attacher
-        tag: v3.2.1
+        tag: v3.4.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -206,14 +206,14 @@ ceph-csi-rbd:
       enabled: true
       image:
         repository: k8s.gcr.io/sig-storage/csi-resizer
-        tag: v1.2.0
+        tag: v1.3.0
         pullPolicy: IfNotPresent
       resources: {}
 
     snapshotter:
       image:
         repository: k8s.gcr.io/sig-storage/csi-snapshotter
-        tag: v4.1.1
+        tag: v4.2.0
         pullPolicy: IfNotPresent
       resources: {}
 

--- a/kubernetes/cray-ceph-csi-rbd/values.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/values.yaml
@@ -97,7 +97,7 @@ ceph-csi-rbd:
 
     registrar:
       image:
-        repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-node-driver-registrar
         tag: v2.4.0
         pullPolicy: IfNotPresent
       resources: {}
@@ -187,7 +187,7 @@ ceph-csi-rbd:
 
     provisioner:
       image:
-        repository: k8s.gcr.io/sig-storage/csi-provisioner
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-provisioner
         tag: v3.1.0
         pullPolicy: IfNotPresent
       resources: {}
@@ -196,7 +196,7 @@ ceph-csi-rbd:
       name: attacher
       enabled: true
       image:
-        repository: k8s.gcr.io/sig-storage/csi-attacher
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-attacher
         tag: v3.4.0
         pullPolicy: IfNotPresent
       resources: {}
@@ -205,14 +205,14 @@ ceph-csi-rbd:
       name: resizer
       enabled: true
       image:
-        repository: k8s.gcr.io/sig-storage/csi-resizer
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-resizer
         tag: v1.3.0
         pullPolicy: IfNotPresent
       resources: {}
 
     snapshotter:
       image:
-        repository: k8s.gcr.io/sig-storage/csi-snapshotter
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-snapshotter
         tag: v4.2.0
         pullPolicy: IfNotPresent
       resources: {}

--- a/kubernetes/cray-ceph-csi-rbd/values.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/values.yaml
@@ -125,6 +125,10 @@ ceph-csi-rbd:
   provisioner:
     name: provisioner
     replicaCount: 3
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 50%
     # if fstype is not specified in storageclass, ext4 is default
     defaultFSType: ext4
     # deployController to enable or disable the deployment of controller which


### PR DESCRIPTION
## Summary and Scope

This is a newer ceph-csi chart that supports setting the upgrade strategy.  Currently the defaults used by the chart are not setup to work with a 3 worker system.

## Issues and Related PRs

* Resolves CASMINST-3857

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Install cephfs/rbd csi 3.4.0 charts.  create deployment/statefulsets for rbd and cephfs pvcs.  upgrade to ceph-csi 3.5.1 moving them from the default namespace into ceph-rbd/ceph-cephfs.  verfiy pods w/ pvcs are still functional.  Move the pods to ensure pvc migration and verify testfiles are intact.  

Test the reverse of this for downgrades

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This will require a brief outage during the upgrade where pods with pvcs will not be able to move.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

