### PR TITLE
fixing sma storage class apply

### DIFF
--- a/kubernetes/cray-ceph-csi-rbd/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-rbd
-version: 3.5.1-1
+version: 3.5.1-2
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter, and attacher for Ceph RBD
 keywords:
   - ceph

--- a/kubernetes/cray-ceph-csi-rbd/templates/post-install.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/templates/post-install.yaml
@@ -31,7 +31,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - "kubectl apply -f /apps/storage_classes/sc-kube.yaml --force; kubectl apply -f /apps/storage_classes/sc-sma.yaml; /scripts/set-default-storageclass.sh --force"
+            - "kubectl apply -f /apps/storage_classes/sc-kube.yaml --force; kubectl apply -f /apps/storage_classes/sc-sma.yaml --force; /scripts/set-default-storageclass.sh --force"
           volumeMounts:
             - name: kube-csi-sc-vol
               mountPath: /apps/storage_classes/sc-kube.yaml


### PR DESCRIPTION


## Summary and Scope

this was missing the force option to re-create the storage class so the proper image feature is present.

## Issues and Related PRs

* Resolves CASMTRIAGE-3674

## Testing

### Tested on:

  * shandy

### Test description:

Applied the storage class config map as it was to get the failure.  Then applied with the proper settings. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

