### PR TITLE
CASMPET-7301: Upgrade to cephcsi v3.14.0

### DIFF
--- a/kubernetes/cray-ceph-csi-rbd/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-rbd
-version: 3.6.2-1
+version: 3.13.0
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter, and attacher for Ceph RBD
 keywords:
   - ceph
@@ -8,12 +8,12 @@ keywords:
   - ceph-csi
 home: https://github.com/Cray-HPE/cray-ceph-csi-rbd
 sources:
-  - https://github.com/ceph/ceph-csi/tree/v3.4.0/charts/ceph-csi-rbd
+  - https://github.com/ceph/ceph-csi/tree/v3.13.0/charts/ceph-csi-rbd
 dependencies:
   - name: ceph-csi-rbd
-    version: 3.6.2
+    version: 3.13.0
     repository: https://ceph.github.io/csi-charts
 maintainers:
   - name: bklei
-icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.4.0/assets/ceph-logo.png
-appVersion: 3.6.2
+icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.13.0/assets/ceph-logo.png
+appVersion: 3.13.0

--- a/kubernetes/cray-ceph-csi-rbd/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-rbd
-version: 3.13.0
+version: 3.14.0
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter, and attacher for Ceph RBD
 keywords:
   - ceph
@@ -8,12 +8,12 @@ keywords:
   - ceph-csi
 home: https://github.com/Cray-HPE/cray-ceph-csi-rbd
 sources:
-  - https://github.com/ceph/ceph-csi/tree/v3.13.0/charts/ceph-csi-rbd
+  - https://github.com/ceph/ceph-csi/tree/v3.14.0/charts/ceph-csi-rbd
 dependencies:
   - name: ceph-csi-rbd
-    version: 3.13.0
+    version: 3.14.0
     repository: https://ceph.github.io/csi-charts
 maintainers:
   - name: bklei
-icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.13.0/assets/ceph-logo.png
-appVersion: 3.13.0
+icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.14.0/assets/ceph-logo.png
+appVersion: 3.14.0

--- a/kubernetes/cray-ceph-csi-rbd/values.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/values.yaml
@@ -97,8 +97,8 @@ ceph-csi-rbd:
 
     registrar:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar
-        tag: v2.4.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-node-driver-registrar
+        tag: v2.9.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -107,7 +107,7 @@ ceph-csi-rbd:
         # XXX quay.io/cephcsi/cephcsi:v3.4.0 has 4 critical (of 8)
         # XXX vulnerabilities, so we're rebuilding it to resolve them.
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
-        tag: v3.6.2
+        tag: v3.13.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -187,8 +187,8 @@ ceph-csi-rbd:
 
     provisioner:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner
-        tag: v3.1.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-provisioner
+        tag: v3.6.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -196,8 +196,8 @@ ceph-csi-rbd:
       name: attacher
       enabled: true
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher
-        tag: v3.4.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-attacher
+        tag: v4.4.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -205,15 +205,15 @@ ceph-csi-rbd:
       name: resizer
       enabled: true
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer
-        tag: v1.4.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-resizer
+        tag: v1.9.0
         pullPolicy: IfNotPresent
       resources: {}
 
     snapshotter:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter
-        tag: v4.2.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-snapshotter
+        tag: v6.2.1
         pullPolicy: IfNotPresent
       resources: {}
 

--- a/kubernetes/cray-ceph-csi-rbd/values.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/values.yaml
@@ -51,10 +51,18 @@ ceph-csi-rbd:
   #     vaultCAVerify: "false"
   encryptionKMSConfig: {}
 
+  # Labels to apply to all resources
+  commonLabels: {}
+
   # Set logging level for csi containers.
   # Supported values from 0 to 5. 0 for general useful logs,
   # 5 for trace level verbosity.
   logLevel: 0
+  # sidecarLogLevel is the variable for Kubernetes sidecar container's log level
+  sidecarLogLevel: 1
+  # Log slow operations at the specified rate.
+  # Operation is considered slow if it outlives its deadline.
+  logSlowOperationInterval: 30s
 
   nodeplugin:
     name: nodeplugin
@@ -95,10 +103,14 @@ ceph-csi-rbd:
         loadBalancerIP: ""
         loadBalancerSourceRanges: []
 
+    profiling:
+      # enable profiling to check for memory leaks
+      enabled: false
+
     registrar:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-node-driver-registrar
-        tag: v2.9.0
+        tag: v2.13.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -107,7 +119,7 @@ ceph-csi-rbd:
         # XXX quay.io/cephcsi/cephcsi:v3.4.0 has 4 critical (of 8)
         # XXX vulnerabilities, so we're rebuilding it to resolve them.
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
-        tag: v3.13.0
+        tag: v3.14.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -188,7 +200,7 @@ ceph-csi-rbd:
     provisioner:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-provisioner
-        tag: v3.6.0
+        tag: v5.2.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -197,7 +209,7 @@ ceph-csi-rbd:
       enabled: true
       image:
         repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-attacher
-        tag: v4.4.0
+        tag: v4.8.1
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -206,14 +218,14 @@ ceph-csi-rbd:
       enabled: true
       image:
         repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-resizer
-        tag: v1.9.0
+        tag: v1.13.2
         pullPolicy: IfNotPresent
       resources: {}
 
     snapshotter:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-snapshotter
-        tag: v6.2.1
+        tag: v8.2.1
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -229,16 +241,13 @@ ceph-csi-rbd:
       enabled: true
 
   topology:
-    # Specifies whether topology based provisioning support should
-    # be exposed by CSI
-    enabled: false
     # domainLabels define which node labels to use as domains
     # for CSI nodeplugins to advertise their domains
     # NOTE: the value here serves as an example and needs to be
     # updated with node labels that define domains of interest
-    domainLabels:
-      - failure-domain/region
-      - failure-domain/zone
+    domainLabels: []
+    # - topology.kubernetes.io/region
+    # - topology.kubernetes.io/zone
 
   #########################################################
   # Variables for 'internal' use please use with caution! #
@@ -260,6 +269,3 @@ ceph-csi-rbd:
   externallyManagedConfigmap: true
   # Name of the configmap used for encryption kms configuration
   kmsConfigMapName: ceph-csi-encryption-kms-config
-
-  # Custom image variables for HPE Cray
-  imagesHost: "dtr.dev.cray.com"


### PR DESCRIPTION
## Summary and Scope

Upgrade cephcsi to the latest v3.14.0 that supports K8s 1.32. The chart should be upgraded only after K8s is upgraded.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7301](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7301)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `beau`
  * Virtual Shasta

### Test description:

After upgrading the chart, created a PVC with rbd provisioner and verified a pod can be created with the new PVC.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

