### PR TITLE
CASMPET-7600: upgrade cephcsi to v3.14.2

### DIFF
--- a/kubernetes/cray-ceph-csi-rbd/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-rbd
-version: 3.14.0
+version: 3.14.2
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter, and attacher for Ceph RBD
 keywords:
   - ceph
@@ -8,12 +8,12 @@ keywords:
   - ceph-csi
 home: https://github.com/Cray-HPE/cray-ceph-csi-rbd
 sources:
-  - https://github.com/ceph/ceph-csi/tree/v3.14.0/charts/ceph-csi-rbd
+  - https://github.com/ceph/ceph-csi/tree/v3.14.2/charts/ceph-csi-rbd
 dependencies:
   - name: ceph-csi-rbd
-    version: 3.14.0
+    version: 3.14.2
     repository: https://ceph.github.io/csi-charts
 maintainers:
-  - name: bklei
-icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.14.0/assets/ceph-logo.png
-appVersion: 3.14.0
+  - name: bo-quan
+icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.14.2/assets/ceph-logo.png
+appVersion: 3.14.2

--- a/kubernetes/cray-ceph-csi-rbd/values.yaml
+++ b/kubernetes/cray-ceph-csi-rbd/values.yaml
@@ -116,10 +116,8 @@ ceph-csi-rbd:
 
     plugin:
       image:
-        # XXX quay.io/cephcsi/cephcsi:v3.4.0 has 4 critical (of 8)
-        # XXX vulnerabilities, so we're rebuilding it to resolve them.
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
-        tag: v3.14.0
+        tag: v3.14.2
         pullPolicy: IfNotPresent
       resources: {}
 


### PR DESCRIPTION
## Summary and Scope

Upgrade cephcsi from v3.14.0 to v3.14.2 for reduced CVE counts.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7600](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7600)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `beau`
  * `fanta`

### Test description:

Followed the cephcsi testing section under https://rndwiki-pro.its.hpecorp.net/display/~lindsay.eliasen@hpe.com/Procedure+to+test+Ceph and verified that cephcsi worked after upgrading the charts using the new cephcsi v3.14.2 image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

